### PR TITLE
Fixed a bug in Evolutions and Types

### DIFF
--- a/PokeApi.NET/Objects/Pokemon.cs
+++ b/PokeApi.NET/Objects/Pokemon.cs
@@ -221,9 +221,9 @@ namespace PokeAPI
 
             Evolutions = source.Keys.Contains(EVS)
                 ? source[EVS].Map<JsonData, Evolution>(data => new Evolution(data)).ToArray() : EmptyEvoArr;
-
-            Type = source[TPS].Map<JsonData, ApiResource>(ParseResource).Select(r => (TypeFlags)r.Id).Aggregate((a, b) => a | b);
-
+            
+            Type = source[TPS].Map<JsonData, ApiResource>(ParseResource).Select(r => (TypeFlags)(1 << r.Id - 1)).Aggregate((a, b) => a | b);
+            
             Species = source[SCS].ToString();
 
             CatchRate      = source.AsInt(CRT);

--- a/PokeApi.NET/Objects/Pokemon.cs
+++ b/PokeApi.NET/Objects/Pokemon.cs
@@ -15,7 +15,7 @@ namespace PokeAPI
             EGS = "egg_groups",
             DSS = "descriptions",
             MVS = "moves",
-            EVS = "evolutins",
+            EVS = "evolutions",
             TPS = "types",
             CRT = "catch_rate",
             SCS = "species",


### PR DESCRIPTION
There was a typo that caused "Evolutions" to not be filled in for Pokemon when parsing the JSON and an error in the logic for assigning Types to a Pokemon.